### PR TITLE
Some datastructures to detect which objects are live.

### DIFF
--- a/src/snapshot/fast-serializer-deserializer.h
+++ b/src/snapshot/fast-serializer-deserializer.h
@@ -18,7 +18,8 @@ class Isolate;
 
 // LAB: An area that contains objects that are part of the snapshot.
 // A lab is always smaller than a 256k page, and always contained in
-// one 256k page. Often they will be much smaller.
+// one 256k page (unless they are in a large object space). Often they
+// will hopefully be much smaller.
 class LinearAllocationBuffer {
  public:
   LinearAllocationBuffer(Zone* zone, int index, AllocationSpace space,
@@ -32,13 +33,13 @@ class LinearAllocationBuffer {
 
   void Expand(Address from, Address to) {
     DCHECK(from >= start_);
-    DCHECK(to <= start_ + kRegularPageSize);
     if (lowest_ > from) lowest_ = from;
     if (highest_ < to) highest_ = to;
   }
 
-  void SetPointsTo(int other);
-  bool PointsTo(int other) const;
+  // Set and get the set of labs this lab points at.
+  void SetPointsTo(int other_index);
+  bool PointsTo(int other_index) const;
 
  private:
   int lab_index_;                   // Unique in a given snapshot.

--- a/src/snapshot/fast-serializer-thoughts.txt
+++ b/src/snapshot/fast-serializer-thoughts.txt
@@ -1,0 +1,111 @@
+Fast snapshots, thoughts.
+
+We can either create a zygote isolate for the purpose or use the original
+isolate. Perhaps easier to start with just using a frozen isolate, so we
+don't have to handle allocation and writing to newly allocated objects.
+
+Problem:  Can we somehow GC-compact the initial isolate to reduce the
+   number of labs and free gaps?  V8 doesn't have a sliding compactor, so
+   you would have to evacuate all.
+
+A fast snapshot consists of a zygote/frozen isolate and some metadata.
+
+We need to populate the zygote isolate with objects with the usual layout.
+OTOH if we are just using a frozen isolate, the pages are already populated.
+
+When serializing, we visit objects recursively, get their sizes, (allocate space
+in the zygote for them unless we are freezing the original data), then do a
+serializing visit, which gives us the other objects.  If we make a zygote,
+pretenure all allocations, make sure they are linear.
+
+We can do this intra-isolate.  For testing, developing.
+
+Maintain a map of old locations -> new locations.  For the frozen (as opposed to
+zygote) solution this isn't needed.
+
+Dynamic number of linear allocation buffers, 'labs', means we can just start a
+new lab if we run out of space on one page.  The bet is that we still have a
+small number of labs pointed to from a given lab.  A lab never spans more than
+one 128k page.
+
+We have an array of labs, built up during serialization.  Index of lab is
+its id.
+
+struct lab_t {
+  uint8_t space_type;  // Large, map, code, trusted, etc.
+  uint32_t lab_start;  // Location in frozen/zygote sandbox.
+                       // This is always rounded down to nearest 128k page.
+  uint32_t start;      // Location of lowest-address object in lab.
+  uint32_t end;        // Location of end of highest-address object in lab.
+};
+
+For each visited slot we add a fixup to an array, sorted later.
+
+struct fixup {
+  uint8_t source_lab;  // The lab in which the object is that needs fixing.
+  uint8_t dest_lab;    // The lab the slot is pointing to.
+  uint32_t offset;     // Location of the slot, in bytes, within the source lab.
+};
+
+The fixups are enough to reconstitute the data because we know the offset of
+the dest lab in the original vs the clone.
+
+The allocated objects have slots that are pre-populated for the
+locations of the dest labs.  On deserialization, if the labs are
+not in the same places, we will have to fix up the slots.
+
+  Problem: Most fixups are compressed-word-aligned, but relative branches in
+  x64 code are not.  Would be nice to restrict to a single page of code, or
+  consecutive code pages.
+
+Idea: We can treat tables like the trusted data tables as just another lab.
+But it has 64 values in it, which complicates things a tiny bit.  However
+if the trusted spaces are 4Gbyte aligned we can probably treat the halves
+as separate relocations. Indexes into the trusted data tables are just
+relocated in the same way.
+
+Time saving insight: The actual in-memory 'serialization format' doesn't
+initially have to have a serialized form.  It can just contain direct pointers
+to the lab pages.
+
+When deserializing:
+
+Read the lab array, and create linear areas in the destination that match
+as much as possible.  For example all labs that are in the same cage are
+attempted to be allocated in the same locations that they were originally.
+If that fails, they are attempted to be allocated in the same pattern
+relative to each other.  When that is done, we generate a fixup bitmap
+for each distinct offset.  Ideally, zero fixup bitmaps, but for in-isolate
+clones there will be at least two for the main cage.  These are cached
+from deserialization to deserialization.
+
+The deserializer for each lab takes a number of bitmaps, an offset for
+each bitmap, a source and a destination. For zero bitmaps, obviously
+there's nothing special to do, and we can use mmap. Specializations for
+1 and 2 bitmaps will use SIMD.  For larger numbers of bitmaps we can
+build a bytemap and use shuffle operations.  See
+https://builders.intel.com/docs/networkbuilders/intel-avx-512-permuting-data-within-and-between-avx-registers-technology-guide-1668169807.pdf
+
+For example this instruction can select one of 16 different 32 bit offsets
+from a register.  It can do this on a 256 bit wide register, so we are getting
+8 different offsets at a time to do an 8-wide 32 bit add on.  The input
+is a set of 32 bit indices, so we would have to expand the bytemap or
+make it into a word-map first.
+https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#techs=AVX_ALL,AVX_512&ig_expand=50,444,647,4986&text=_mm256_permutex2var_epi32
+See also
+https://claude.ai/public/artifacts/308826fe-7695-4981-8436-32fab8cf01bf
+
+Time saving insight: Initially we can just generate a byte map and use:
+
+void copy(uint32_t* source, uint32_t* destination, int count, uint8_t* byte_map, uint32_t* offsets) {
+  for (int i = 0; i < count; i++) {
+    destination[i] = source[i] + offsets[byte_map[i]];
+  }
+}
+
+This is probably already faster than normaly serialization/deserialization.
+
+Bet:
+  We have a limited number of labs.
+  If we play our cards right, many of the fixups disappear.
+  If we play our cards right, all of the fixups disappear.

--- a/src/snapshot/fast-serializer.cc
+++ b/src/snapshot/fast-serializer.cc
@@ -1,0 +1,45 @@
+// Copyright 2025 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "src/snapshot/fast-serializer.h"
+
+namespace v8 {
+namespace internal {
+
+bool FastSerializer::IsMarked(Tagged<HeapObject> object) {
+  Address lab_start = RoundDown(object->address(), kRegularPageSize);
+  uint64_t*& bitmap = lab_liveness_map_[lab_start];
+  if (bitmap == nullptr) {
+    // We don't yet have a liveness map for this lab, so we allocate one.
+    // Each 32 bit word is a bit in the map so we divide the size with 32.
+    bitmap = reinterpret_cast<uint64_t*>(zone_.Allocate<uint64_t>(kRegularPageSize / 32));
+  }
+  constexpr int kWordSize = sizeof(uint32_t);  // Words on a compressed heap.
+  size_t byte_offset = object->address() - lab_start;
+  size_t index = byte_offset / (64 * kWordSize);
+  int bit_number = (byte_offset / kWordSize) & 63;
+  return (bitmap[index] & (uint64_t{1} << bit_number)) != 0;
+}
+
+void FastSerializer::Mark(Tagged<HeapObject> object, size_t size) {
+  Address lab_start = RoundDown(object->address(), kRegularPageSize);
+  auto it = lab_liveness_map_.find(lab_start);
+  uint64_t* bitmap = (it == lab_liveness_map_.end()) ? nullptr : it->second;
+  // We already called IsMarked so the bitmap must exist.
+  DCHECK(bitmap != nullptr);
+
+  size_t start_offset = object->address() - lab_start;
+  size_t end_offset = object->address() + size - lab_start;
+  end_offset = std::max(end_offset, size_t{kRegularPageSize});
+  constexpr int kWordSize = sizeof(uint32_t);  // Words on a compressed heap.
+  // Mark all words in the object. TODO(erikcorry): Do this more efficiently.
+  for (size_t o = start_offset; o < end_offset; o += sizeof(uint32_t)) {
+    size_t index = o / (64 * kWordSize);
+    int bit_number = (o / kWordSize) & 63;
+    bitmap[index] |= uint64_t{1} << bit_number;
+  }
+}
+
+}  // namespace internal
+}  // namespace v8

--- a/src/snapshot/fast-serializer.h
+++ b/src/snapshot/fast-serializer.h
@@ -1,0 +1,123 @@
+// Copyright 2025 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef V8_SNAPSHOT_FAST_SERIALIZER_H_
+#define V8_SNAPSHOT_FAST_SERIALIZER_H_
+
+#include "src/codegen/external-reference-encoder.h"
+#include "src/common/assert-scope.h"
+#include "src/execution/isolate.h"
+#include "src/handles/global-handles.h"
+#include "src/logging/log.h"
+#include "src/objects/abstract-code.h"
+#include "src/objects/bytecode-array.h"
+#include "src/objects/instruction-stream.h"
+#include "src/objects/objects.h"
+#include "src/snapshot/fast-serializer-deserializer.h"
+#include "src/snapshot/snapshot.h"
+#include "src/utils/identity-map.h"
+
+namespace v8 {
+namespace internal {
+
+// The 'fast' refers to the speed of deserialization.  The serializer
+// itself is not particularly fast.
+class FastSerializer {
+ public:
+  FastSerializer(Isolate* isolate, Snapshot::SerializerFlags flags);
+  ~FastSerializer();
+  FastSerializer(const FastSerializer&) = delete;
+  FastSerializer& operator=(const FastSerializer&) = delete;
+
+  Isolate* isolate() const { return isolate_; }
+
+  // The pointer compression cage base value used for decompression of all
+  // tagged values except references to InstructionStream objects.
+  PtrComprCageBase cage_base() const {
+#if V8_COMPRESS_POINTERS
+    return cage_base_;
+#else
+    return PtrComprCageBase{};
+#endif  // V8_COMPRESS_POINTERS
+  }
+
+  void VisitRootPointers(Root root, const char* description,
+                         FullObjectSlot start, FullObjectSlot end);
+  void SerializeRootObject(FullObjectSlot slot);
+
+  bool queue_empty() { return queue_.size() == 0; }
+
+  bool IsMarked(Tagged<HeapObject> object);
+  void Mark(Tagged<HeapObject> object, size_t size_in_bytes);
+
+ private:
+  DISALLOW_GARBAGE_COLLECTION(no_gc_)
+
+  class ObjectSerializer;
+
+  Isolate* isolate_;
+  // Used for things that live during serialization, but die once the snapshot
+  // is created.
+  Zone zone_;
+  SmallZoneVector<Tagged<HeapObject>, 10> queue_;
+  // One bit per word used to mark objects as white (not yet part of the
+  // snapshot) or black/gray (have been found).  Objects in the queue are grey,
+  // those no longer in the queue are black.  We mark the whole object, so at
+  // the end this map shows the words that are in the source lab, but not part
+  // of the snapshot.  Manipulated by Mark() and IsMarked().
+  ZoneAbslFlatHashMap<Address, uint64_t*> lab_liveness_map_;
+  const PtrComprCageBase cage_base_;
+  ExternalReferenceEncoder external_reference_encoder_;
+  const Snapshot::SerializerFlags flags_;
+
+  FastSnapshot* fast_snapshot_;
+  friend class ObjectSerializer;
+};
+
+class FastSerializer::ObjectSerializer : public ObjectVisitor {
+ public:
+  ObjectSerializer(FastSerializer* serializer)
+      : isolate_(serializer->isolate_),
+        serializer_(serializer) {}
+  void SerializeObject();
+  void VisitPointers(Tagged<HeapObject> host, ObjectSlot start,
+                     ObjectSlot end) override;
+  void VisitPointers(Tagged<HeapObject> host, MaybeObjectSlot start,
+                     MaybeObjectSlot end) override;
+  void VisitInstructionStreamPointer(Tagged<Code> host,
+                                     InstructionStreamSlot slot) override;
+  void VisitEmbeddedPointer(Tagged<InstructionStream> host,
+                            RelocInfo* target) override;
+  void VisitExternalReference(Tagged<InstructionStream> host,
+                              RelocInfo* rinfo) override;
+  void VisitInternalReference(Tagged<InstructionStream> host,
+                              RelocInfo* rinfo) override;
+  void VisitCodeTarget(Tagged<InstructionStream> host,
+                       RelocInfo* target) override;
+  void VisitOffHeapTarget(Tagged<InstructionStream> host,
+                          RelocInfo* target) override { UNREACHABLE(); }
+  void VisitExternalPointer(Tagged<HeapObject> host,
+                            ExternalPointerSlot slot) override;
+  void VisitIndirectPointer(Tagged<HeapObject> host, IndirectPointerSlot slot,
+                            IndirectPointerMode mode) override;
+  void VisitTrustedPointerTableEntry(Tagged<HeapObject> host,
+                                     IndirectPointerSlot slot) override;
+  void VisitProtectedPointer(Tagged<TrustedObject> host,
+                             ProtectedPointerSlot slot) override;
+  void VisitProtectedPointer(Tagged<TrustedObject> host,
+                             ProtectedMaybeObjectSlot slot) override;
+  void VisitCppHeapPointer(Tagged<HeapObject> host,
+                           CppHeapPointerSlot slot) override { UNREACHABLE(); }
+  void VisitJSDispatchTableEntry(Tagged<HeapObject> host,
+                                 JSDispatchHandle handle) override;
+
+ private:
+  Isolate* isolate_;
+  FastSerializer* serializer_;
+};
+
+}  // namespace internal
+}  // namespace v8
+
+#endif  // V8_SNAPSHOT_FAST_SERIALIZER_H_


### PR DESCRIPTION
Live = part of the snapshot we want to create.

We use a bitmap that marks all bits of the live
objects, which will be useful later when handling
gaps etc.

It should be possible to mark most objects with a
single bitwise operation on one 64 bit word.  For now it's an inefficient loop.

Code is untested, just to show direction.