### PR TITLE
Gets through visiting of all objects for read-only snapshot.

### DIFF
--- a/src/heap/setup-heap-internal.cc
+++ b/src/heap/setup-heap-internal.cc
@@ -367,6 +367,10 @@ bool Heap::CreateEarlyReadOnlyMapsAndObjects() {
   //      them to be checked with a single less-than if we know we have a map.
   //   4. The symbol map is with the string maps, for similarly fast Name
   //      checks.
+  //
+  // Note that the ReadOnly serializer knows that the undefined object is the
+  // first and the Boolean map is the last one with a fixed location, so if
+  // that changes, update read-only-serializer.cc.
 
   Tagged<HeapObject> obj;
   {

--- a/src/snapshot/fast-serializer.cc
+++ b/src/snapshot/fast-serializer.cc
@@ -482,9 +482,15 @@ void FastSerializer::ObjectSerializer::VisitTrustedPointerTableEntry(
 }
 
 void FastSerializer::ObjectSerializer::VisitJSDispatchTableEntry(
-    Tagged<HeapObject>,
-    v8::base::StrongAlias<JSDispatchHandleAliasTag, unsigned int>) {
-  UNREACHABLE();
+    Tagged<HeapObject>, JSDispatchHandle handle) {
+  if (serializer_->is_read_only()) {
+    // There is a read-only root which is the singleton many_closures_cell
+    // which contains an unused index into the JSDispatchTable.
+    CHECK_EQ(handle, kNullJSDispatchHandle);
+  } else {
+    // TODO: Handle JSDispatchTable indices.
+    UNREACHABLE();
+  }
 }
 
 }  // namespace internal

--- a/src/snapshot/fast-serializer.cc
+++ b/src/snapshot/fast-serializer.cc
@@ -35,7 +35,7 @@ FastSerializer::FastSerializer(Isolate* isolate,
   Address location = 0;
   roots_lab_ = zone_.New<LinearAllocationBuffer>(
       &zone_, next_lab_index_++, kIgnoreAllocationSpace, AddressSpace::kRoots,
-      location, location);
+      location);
   for (int space = 0; space < kNumberOfAddressSpaces; space++) {
     address_space_fullnesses_[space] = 0;
   }
@@ -151,7 +151,9 @@ void FastSerializer::VisitRootPointers(
     size_t offset = roots_lab_->highest();
     roots_lab_->Expand(offset, offset + sizeof(Address));
     snapshot_->root_lab_data_.push_back((*current).ptr());
-    VisitSlot(roots_lab_, offset, current, current);
+    FullObjectSlot new_slot(
+        reinterpret_cast<Address>(roots_lab_->BackingAt(offset)));
+    VisitSlot(roots_lab_, offset, current, new_slot);
   }
 }
 

--- a/src/snapshot/fast-serializer.h
+++ b/src/snapshot/fast-serializer.h
@@ -65,6 +65,15 @@ class FastSerializer : public RootVisitor {
  protected:
   virtual bool is_read_only() { return false; }
 
+  void AddToSnapshot(Tagged<HeapObject> heap_object);
+
+  struct LabAndOffset {
+    LinearAllocationBuffer* lab;
+    size_t offset;
+  };
+
+  LabAndOffset FoundObject(Tagged<HeapObject> heap_object);
+
  private:
   void VisitRootPointers(Root root, const char* description,
                          FullObjectSlot start, FullObjectSlot end);
@@ -98,11 +107,6 @@ class FastSerializer : public RootVisitor {
   // Find a lab in a given space that has space enough for an object.
   LinearAllocationBuffer* GetOrCreatePackedLab(Tagged<HeapObject> object,
                                                size_t size);
-
-  struct LabAndOffset {
-    LinearAllocationBuffer* lab;
-    size_t offset;
-  };
 
   // Looks up in this serializer and the others to find the destination for the
   // object at this address.

--- a/src/snapshot/read-only-serializer.cc
+++ b/src/snapshot/read-only-serializer.cc
@@ -550,16 +550,70 @@ OldReadOnlySerializer::~OldReadOnlySerializer() {
   OutputStatistics("OldReadOnlySerializer");
 }
 
+// Helper to make sure we discover the first objects in the correct order so
+// they have the right layout in the read-only page.
+class SpecialOrderVisitor : public RootVisitor {
+ public:
+  SpecialOrderVisitor(ReadOnlySerializer* serializer,
+                      Tagged<HeapObject> first_object,
+                      Tagged<HeapObject> last_object)
+      : serializer_(serializer),
+        first_object_(first_object),
+        last_object_(last_object) {}
+
+  virtual void VisitRootPointers(Root root, const char* description,
+                                 FullObjectSlot start,
+                                 FullObjectSlot end) override {
+    // All the objects with a defined order are in the roots, so we will see
+    // them all here at some point.
+    for (FullObjectSlot current = start; current < end; ++current) {
+      Tagged<HeapObject> obj = Cast<HeapObject>(*current);
+      if (first_object_.address() <= obj.address() &&
+          obj.address() <= last_object_.address()) {
+        CHECK(list_fullness_ < kListSize);
+        list_[list_fullness_++] = obj;
+      }
+    }
+  }
+
+  void AllocateFoundObjects() {
+    // They were created in the right layout by setup-heap-internal.cc
+    // so if we sort by address we will get the correct order.
+    std::sort(list_, list_ + list_fullness_,
+              [](Tagged<HeapObject>& a, Tagged<HeapObject>& b) {
+                return a.address() < b.address();
+              });
+
+    // Now that we have them, allocate their locations in the snapshot.
+    for (int i = 0; i < list_fullness_; i++) serializer_->FoundObject(list_[i]);
+  }
+
+ private:
+  static constexpr int kListSize = 100;
+  ReadOnlySerializer* serializer_;
+  Tagged<HeapObject> first_object_;
+  Tagged<HeapObject> last_object_;
+  Tagged<HeapObject> list_[kListSize];
+  int list_fullness_ = 0;
+};
+
 void ReadOnlySerializer::Serialize() {
   DisallowGarbageCollection no_gc;
 
-  ReadOnlyRoots read_only_roots(isolate());
-  read_only_roots.Iterate(this);
+  // We need to start with the objects that are in fixed positions for
+  // static roots optimizations.  This is all the objects up to and including
+  // the boolean map.  See comment in setup-heap-internal.cc. By processing
+  // them up here, they will be placed first in the linear allocation buffer.
+  Tagged<HeapObject> first_fixed =
+      ReadOnlyRoots(isolate()->heap()).undefined_value();
+  Tagged<HeapObject> last_fixed =
+      ReadOnlyRoots(isolate()->heap()).boolean_map();
+  SpecialOrderVisitor special_orderer(this, first_fixed, last_fixed);
 
-  ReadOnlyHeapObjectIterator it(isolate()->read_only_heap());
-  for (Tagged<HeapObject> o = it.Next(); !o.is_null(); o = it.Next()) {
-    CheckRehashability(o);
-  }
+  ReadOnlyRoots read_only_roots(isolate());
+  read_only_roots.Iterate(&special_orderer);
+  special_orderer.AllocateFoundObjects();
+  read_only_roots.Iterate(this);
 
   ProcessQueue();  // Close transitivity.
 }

--- a/src/snapshot/read-only-serializer.h
+++ b/src/snapshot/read-only-serializer.h
@@ -23,6 +23,8 @@ class V8_EXPORT_PRIVATE ReadOnlySerializer : public FastSerializer {
 
  protected:
   virtual bool is_read_only() { return true; }
+
+  friend class SpecialOrderVisitor;
 };
 
 // TODO(jgruber): Now that this does a memcpy-style serialization, there is no


### PR DESCRIPTION
Also gets through visiting all the objects for the startup snapshot.

Fails because there is no serialization format for the collected information yet.

May not be the right approach to getting the read-only objects in the right
place.